### PR TITLE
SlidingTabLayout - Default toggleButton

### DIFF
--- a/src/main/java/org/kairos/layouts/SlidingTabLayout.java
+++ b/src/main/java/org/kairos/layouts/SlidingTabLayout.java
@@ -53,6 +53,9 @@ public class SlidingTabLayout extends VBox {
                 viewPager.setCurrentItem(tabStrip.getChildren().indexOf(tabPressed));
                 toggleButtonState(tabStrip.getChildren().indexOf(tabPressed));
             });
+            if (i == 0) {
+                tab.setSelected(true);
+            }
             tabStrip.getChildren().add(tab);
         }
 


### PR DESCRIPTION
Sorry, just forgot to setup the default toggleButton to true.

You also need to update kairos-framework to this version in gradle.